### PR TITLE
restrict textarea to vertical resizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,10 @@
 		.showspent.hide { display: none; }
 		.showremaining.hide { display: none; }
 		.showtotal.hide { display: none; }
+
+		#exportfield {
+			resize: vertical;
+		}
 	</style>
 
 	<!-- Firefox, please -->


### PR DESCRIPTION
Vertical resizing is pretty useful, but horizontal resizing is annoying and ugly, and unfortunately it's the default for textareas in Chrome (and probably all browsers).